### PR TITLE
fix: clarify DID creator demo safety

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -4,9 +4,16 @@ This directory contains tools to help you create and manage DIDs for the Ayra Tr
 
 ## Available Tools
 
-### DID Peer 2 Generator & Resolver
+### DID Peer 2 Local Demo Generator & Resolver
 
-The primary tool in this directory is a generator and resolver for `DID:peer:2` identifiers with support for Trust Registry and Ecosystem DIDs. It uses Streamlit for the web interface and cryptographic libraries to generate DID keys and services.
+The primary tool in this directory is a local demo generator and resolver for
+`DID:peer:2` identifiers with support for Trust Registry and Ecosystem service
+descriptors. It uses Streamlit for the web interface and cryptographic libraries
+to generate DID keys and services.
+
+Ayra profile identifiers are `did:webvh` DIDs. This tool is only a local
+service-profile encoding demo; generated `did:peer` values are not production
+Ayra ecosystem, trust registry, or cluster IDs.
 
 - [DID Creator UI](./did_creator_ui.py) - Web interface for generating DIDs
 - [DID Peer Utils](./did_peer_utils.py) - Core utilities for DID generation and resolution
@@ -46,11 +53,14 @@ The primary tool in this directory is a generator and resolver for `DID:peer:2` 
 
 1. **Generate Trust Registry DID**:
    - This generates a DID associated with the Trust Registry.
-   - The output includes the DID, Ed25519 Private Key, and X25519 Private Key.
+   - The output includes the DID and demo-only Ed25519/X25519 private keys.
 
 2. **Generate Ecosystem DID**:
    - This generates a DID for an ecosystem that points to the previously generated Trust Registry DID.
-   - The output includes the Ecosystem DID with its associated private keys.
+   - The output includes the Ecosystem DID with its associated demo-only private keys.
+
+The displayed private keys are for local demonstrations only. Do not use them in
+production deployments, logs, tickets, or shared documentation.
 
 3. **Resolve a DID**:
    - Input any DID string into the resolver to obtain the DID document.

--- a/tools/did_creator_ui.py
+++ b/tools/did_creator_ui.py
@@ -1,11 +1,33 @@
 #!/usr/bin/env python
 
 import streamlit as st
-import json
 from did_peer_utils import generate_did_peer2, resolve_did_peer2
 
-st.set_page_config(page_title="DID Peer 2 Generator")
-st.title("DID Peer 2 Generator & Resolver")
+TRQP_TR_PROFILE_URL = "https://ayra.forum/profiles/trqp/tr/v2"
+TRQP_EGF_PROFILE_URL = "https://ayra.forum/profiles/trqp/egfURI/v1"
+
+
+def show_demo_private_keys(ed25519_hex, x25519_hex):
+    """Show generated private keys with clear demo-only warnings."""
+    st.warning(
+        "Demo-only private keys: do not paste these keys into production systems, "
+        "logs, tickets, or shared documentation. Generate production keys with your "
+        "approved key-management process."
+    )
+    with st.expander("Show demo private keys"):
+        st.code(
+            f"Ed25519 private key (hex): {ed25519_hex}\n"
+            f"X25519 private key (hex): {x25519_hex}"
+        )
+
+
+st.set_page_config(page_title="DID Peer 2 Local Demo")
+st.title("DID Peer 2 Local Demo Generator & Resolver")
+st.warning(
+    "Ayra profile identifiers are did:webvh DIDs. This DID Peer 2 tool is a "
+    "local service-profile encoding demo only; do not use generated did:peer "
+    "values as production Ayra ecosystem, trust registry, or cluster IDs."
+)
 
 # Ensure that the Trust Registry DID is stored in session_state
 if "trust_registry_did" not in st.session_state:
@@ -33,7 +55,7 @@ if mode == "Generate":
                     "id": "#tr-1",
                     "type": "TRQP",
                     "serviceEndpoint": {
-                        "profile": "https://trustoverip.org/profiles/trp/v2",
+                        "profile": TRQP_TR_PROFILE_URL,
                         "uri": trqp_endpoint,
                         "integrity": "122041dd7b6443542e75701aa98a0c235952a28a0d851b11564d20022ab11d2589a8",
                     },
@@ -47,74 +69,62 @@ if mode == "Generate":
             st.success("Successfully generated Trust Registry DID!")
             st.code(tr_did, language="bash")
 
-            st.write("**Ed25519 Private Key (hex):**", tr_ed_hex)
-            st.write("**X25519 Private Key (hex):**", tr_x_hex)
+            show_demo_private_keys(tr_ed_hex, tr_x_hex)
 
             # Store it in session_state
             st.session_state["trust_registry_did"] = tr_did
         except Exception as e:
             st.error(f"Error generating Trust Registry DID: {str(e)}")
 
-    # Only display next step if we have a TR DID
-    if True:  # st.session_state["trust_registry_did"]:
-        st.subheader("2) Generate Ecosystem DID that references the Trust Registry DID")
+    st.subheader("2) Generate Ecosystem DID that references the Trust Registry DID")
 
-        ec_method_prefix = st.text_input(
-            "Ecosystem DID Method Prefix", value="did:peer:2"
-        )
-        egf_uri = st.text_input(
-            "Ecosystem Governance Framework URI", value="https://localhost:3000/terms"
-        )
-        tr_did = st.text_input("Trust Registry DID's", value="")
-        generate_ecosystem = st.button("Generate Ecosystem DID")
-        if generate_ecosystem:
-            if not tr_did:
-                st.error(
-                    "Trust Registry DID is not generated yet. Please generate it first."
-                )
-            else:
-                ecosystem_config = {
-                    "services": [
-                        {
-                            "id": "#egfURI",
-                            "type": "egfURI",
-                            "serviceEndpoint": {
-                                "profile": "https://trustoverip.org/profiles/trp/egfURI/v1",
-                                "uri": egf_uri,
-                                "integrity": "122041dd7b6443542e75701aa98a0c235951a28a0d851b11564d20022ab11d2589a8",
-                            },
+    ec_method_prefix = st.text_input("Ecosystem DID Method Prefix", value="did:peer:2")
+    egf_uri = st.text_input(
+        "Ecosystem Governance Framework URI", value="https://localhost:3000/terms"
+    )
+    tr_did = st.text_input(
+        "Trust Registry DID",
+        value=st.session_state.get("trust_registry_did") or "",
+        help="Generate a Trust Registry DID first or paste an existing DID here.",
+    )
+    generate_ecosystem = st.button("Generate Ecosystem DID")
+    if generate_ecosystem:
+        if not tr_did:
+            st.error("Please generate or input the Trust Registry DID first.")
+        else:
+            ecosystem_config = {
+                "services": [
+                    {
+                        "id": "#egfURI",
+                        "type": "egfURI",
+                        "serviceEndpoint": {
+                            "profile": TRQP_EGF_PROFILE_URL,
+                            "uri": egf_uri,
+                            "integrity": "122041dd7b6443542e75701aa98a0c235951a28a0d851b11564d20022ab11d2589a8",
                         },
-                    ]
-                }
+                    },
+                    {
+                        "id": "#trust-registry",
+                        "type": "TrustRegistryService",
+                        "serviceEndpoint": {
+                            "profile": TRQP_TR_PROFILE_URL,
+                            "uri": tr_did,
+                            "integrity": "example_integrity_hash_value",
+                        },
+                    },
+                ]
+            }
 
-                # Add the service URI to the Ecosystem DID configuration
-                if tr_did:
-                    ecosystem_config["services"].append(
-                        {
-                            "id": "#TRQP",
-                            "type": "TRQP",
-                            "serviceEndpoint": {
-                                "profile": "https://example.org/profiles/ecosystemService/v1",
-                                "uri": tr_did,
-                                "integrity": "example_integrity_hash_value",
-                            },
-                        }
-                    )
-                else:
-                    st.error("Please input the trust registry DID")
-                    raise "no trust registry DID"
-                try:
-                    print("Created ecosystem DID")
-                    ec_did, ec_ed_hex, ec_x_hex = generate_did_peer2(
-                        ecosystem_config, ec_method_prefix
-                    )
-                    st.success("Successfully generated Ecosystem DID!")
-                    st.code(ec_did, language="bash")
+            try:
+                ec_did, ec_ed_hex, ec_x_hex = generate_did_peer2(
+                    ecosystem_config, ec_method_prefix
+                )
+                st.success("Successfully generated Ecosystem DID!")
+                st.code(ec_did, language="bash")
 
-                    st.write("**Ed25519 Private Key (hex):**", ec_ed_hex)
-                    st.write("**X25519 Private Key (hex):**", ec_x_hex)
-                except Exception as e:
-                    st.error(f"Error generating Ecosystem DID: {str(e)}")
+                show_demo_private_keys(ec_ed_hex, ec_x_hex)
+            except Exception as e:
+                st.error(f"Error generating Ecosystem DID: {str(e)}")
 
 # --------------------------------------------------------------
 # Mode: Resolve


### PR DESCRIPTION
## Thinking Path

AYR-249 came from review feedback that the DID creator examples could mislead implementers. The key issue is that Ayra profile identifiers are `did:webvh`, while the existing helper generates `did:peer:2` demo DIDs. I treated the tool as a local service-profile encoding demo rather than a production Ayra DID creator.

## What Changed

- Updated DID service profile examples to the canonical Ayra profile URLs from `spec/profile.md`.
- Added prominent UI and README warnings that the tool is a local `did:peer:2` demo and not a production Ayra DID generator.
- Marked generated private keys as demo-only and hid them behind an expander.
- Removed the dead `if True` gate, debug `print`, stale example URL, and invalid string `raise` path.
- Used `TrustRegistryService` for the ecosystem trust registry service descriptor.

## Verification

- `python3 -m py_compile tools/did_creator_ui.py`
- Custom stale-pattern check for removed unsafe/stale strings:
  - `trustoverip.org/profiles/trp`
  - `example.org/profiles/ecosystemService`
  - `if True`
  - `raise "no trust registry DID"`
  - `print(`
- Custom expected-pattern check for Ayra profile URLs, `did:webvh`, local-demo warnings, and private-key warnings.
- `git diff --check origin/main...HEAD`

## Risks

- The tool still generates `did:peer:2` DIDs; this PR intentionally labels it as a local demo instead of converting it into a full `did:webvh` production generator.
- UI copy is more cautionary, which may reduce confusion but also makes the tool's scope narrower.

## Model Used

OpenAI GPT-5.5 via Hermes Agent CLI.

## Checklist

- [x] Scope matches AYR-249.
- [x] No secrets or customer data committed.
- [x] Focused verification completed.
- [x] Documentation updated for behavior/safety expectations.
