### PR TITLE
fix: align Ayra metadata schema contract

### DIFF
--- a/.github/workflows/render-specs.yaml
+++ b/.github/workflows/render-specs.yaml
@@ -44,8 +44,11 @@ jobs:
               print(f"validated {path}")
           PY
 
+      - name: Check metadata schema drift
+        run: python scripts/check_metadata_schema_drift.py
+
       - name: Compile Python smoke-test tools
-        run: python -m compileall -q tests tools
+        run: python -m compileall -q scripts tests tools
 
   build-and-deploy-spec:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Interactive Swagger UI rendering of the TRQP and Ayra Profile API:
 ## Schemas
 
 - [TRQP JSON Schemas](./trqp/schema/) -- JSON Schema definitions for TRQP v2.0 authorization and recognition queries and responses.
-- [Ayra Metadata Schema](./schema/ayra_metadata.jsonschema) -- JSON Schema for Ayra Trust Registry metadata.
+- [Ayra Metadata Schema](./schema/ayra_metadata.jsonschema) -- JSON Schema for the Ayra `GET /metadata` extension. It mirrors the OpenAPI `TrustRegistryMetadata` component and requires `ecosystem_did` and `description`.
 
 ## Getting Started
 

--- a/guides/implementers_guide.md
+++ b/guides/implementers_guide.md
@@ -104,7 +104,7 @@ The following table maps TRQP v2.0 conformance requirements to what an Ayra impl
 | **Error format** | RFC 7807 Problem Details | RFC 7807 Problem Details |
 | **HTTP status codes** | 200, 400, 401, 404, 500 | 200, 400, 401, 404, 500 |
 | **Response signing** | Not required by TRQP core | MUST return JWS signed by the Trust Registry controller |
-| **Metadata endpoint** | Not defined in TRQP core | RECOMMENDED: `GET /metadata` (Ayra extension) |
+| **Metadata endpoint** | Not defined in TRQP core | RECOMMENDED: `GET /metadata` (Ayra extension) returning `ecosystem_did` and `description`, with optional `trustregistry_did`, `egf_did`, `name`, and `controllers` |
 | **Lookup endpoints** | Not defined in TRQP core | RECOMMENDED: assurance levels, authorizations, DID methods (Ayra extensions) |
 | **Ecosystem DID** | Not prescribed | MUST be `did:webvh` with at least two service endpoints |
 | **Trust Registry DID** | Not prescribed | MUST be `did:webvh` with at least one service endpoint |

--- a/schema/ayra_metadata.jsonschema
+++ b/schema/ayra_metadata.jsonschema
@@ -1,26 +1,33 @@
 {
   "$id": "ayra-metadata",
   "title": "AyraMetadata",
+  "description": "Ayra profile extension metadata returned by GET /metadata. TRQP v2.0 core does not prescribe a metadata endpoint; this schema defines the Ayra Trust Network profile contract.",
   "type": "object",
   "required": [
-    "id",
-    "name",
-    "description",
-    "controllers"
+    "ecosystem_did",
+    "description"
   ],
   "properties": {
-    "id": {
+    "ecosystem_did": {
       "type": "string",
-      "description": "Unique identifier of the Trust Registry. A DID (see DID-Core)"
+      "description": "Unique identifier of the ecosystem that the Trust Registry is associated with. This is used in TRQP queries as the ecosystem identifier value."
     },
-    "name": {
+    "trustregistry_did": {
       "type": "string",
-      "description": "Human-readable name of the Trust Registry."
+      "description": "Unique identifier, as a DID, of the Trust Registry."
+    },
+    "egf_did": {
+      "type": "string",
+      "description": "Primary Ecosystem Governance Framework (EGF), identified by DID, for the ecosystem."
     },
     "description": {
       "type": "string",
       "maxLength": 4096,
       "description": "A description of the Trust Registry."
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable name of the Trust Registry."
     },
     "controllers": {
       "type": "array",
@@ -29,10 +36,6 @@
         "type": "string"
       },
       "minItems": 1
-    },
-    "default_egf_did": {
-      "type": "string",
-      "description": "Default EGF, identified by DID, that will be used if none is supplied in various queries."
     }
   },
   "additionalProperties": false

--- a/scripts/check_metadata_schema_drift.py
+++ b/scripts/check_metadata_schema_drift.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Check Ayra metadata JSON Schema matches OpenAPI TrustRegistryMetadata.
+
+This deliberately uses only the Python standard library so the check can run in
+CI before optional tooling is installed. It extracts the small OpenAPI component
+surface this repository owns (required fields, property names, and
+additionalProperties) and compares it with schema/ayra_metadata.jsonschema.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+JSON_SCHEMA_PATH = ROOT / "schema" / "ayra_metadata.jsonschema"
+OPENAPI_PATH = ROOT / "trqp_ayra_profile_swagger.yaml"
+COMPONENT_NAME = "TrustRegistryMetadata"
+
+
+def _indent(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def _component_lines(openapi_text: str) -> tuple[int, list[str]]:
+    lines = openapi_text.splitlines()
+    for index, line in enumerate(lines):
+        if line.strip() == f"{COMPONENT_NAME}:":
+            component_indent = _indent(line)
+            block: list[str] = []
+            for child in lines[index + 1 :]:
+                if child.strip() and _indent(child) <= component_indent:
+                    break
+                block.append(child)
+            return component_indent, block
+    raise SystemExit(f"Could not find components.schemas.{COMPONENT_NAME} in {OPENAPI_PATH}")
+
+
+def _extract_required(block: list[str]) -> list[str]:
+    required: list[str] = []
+    in_required = False
+    required_indent = 0
+    for line in block:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped == "required:":
+            in_required = True
+            required_indent = _indent(line)
+            continue
+        if in_required:
+            if _indent(line) <= required_indent:
+                break
+            if stripped.startswith("-"):
+                required.append(stripped[1:].strip())
+    return required
+
+
+def _extract_properties(block: list[str]) -> set[str]:
+    properties: set[str] = set()
+    in_properties = False
+    properties_indent = 0
+    property_indent = 0
+    for line in block:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped == "properties:":
+            in_properties = True
+            properties_indent = _indent(line)
+            property_indent = properties_indent + 2
+            continue
+        if in_properties:
+            if _indent(line) <= properties_indent:
+                break
+            if _indent(line) == property_indent and stripped.endswith(":"):
+                properties.add(stripped[:-1])
+    return properties
+
+
+def _extract_additional_properties(block: list[str]) -> bool | None:
+    properties_indent = None
+    for line in block:
+        stripped = line.strip()
+        if stripped == "properties:":
+            properties_indent = _indent(line)
+        if stripped.startswith("additionalProperties:"):
+            # Only accept schema-level additionalProperties, not a mistaken
+            # property named additionalProperties inside properties.
+            if properties_indent is None or _indent(line) <= properties_indent:
+                value = stripped.split(":", 1)[1].strip().lower()
+                if value == "false":
+                    return False
+                if value == "true":
+                    return True
+                return None
+    return None
+
+
+def load_openapi_metadata_contract() -> dict[str, object]:
+    _, block = _component_lines(OPENAPI_PATH.read_text(encoding="utf-8"))
+    return {
+        "required": _extract_required(block),
+        "properties": _extract_properties(block),
+        "additionalProperties": _extract_additional_properties(block),
+    }
+
+
+def load_json_schema_metadata_contract() -> dict[str, object]:
+    schema = json.loads(JSON_SCHEMA_PATH.read_text(encoding="utf-8"))
+    return {
+        "required": schema.get("required", []),
+        "properties": set(schema.get("properties", {}).keys()),
+        "additionalProperties": schema.get("additionalProperties"),
+    }
+
+
+def main() -> int:
+    json_contract = load_json_schema_metadata_contract()
+    openapi_contract = load_openapi_metadata_contract()
+
+    failures: list[str] = []
+    if set(json_contract["required"]) != set(openapi_contract["required"]):
+        failures.append(
+            "required fields differ: "
+            f"jsonschema={sorted(json_contract['required'])} "
+            f"openapi={sorted(openapi_contract['required'])}"
+        )
+    if json_contract["properties"] != openapi_contract["properties"]:
+        failures.append(
+            "properties differ: "
+            f"jsonschema={sorted(json_contract['properties'])} "
+            f"openapi={sorted(openapi_contract['properties'])}"
+        )
+    if json_contract["additionalProperties"] != openapi_contract["additionalProperties"]:
+        failures.append(
+            "additionalProperties differs: "
+            f"jsonschema={json_contract['additionalProperties']} "
+            f"openapi={openapi_contract['additionalProperties']}"
+        )
+
+    if failures:
+        print("Ayra metadata schema drift detected:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("Ayra metadata JSON Schema matches OpenAPI TrustRegistryMetadata.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/trqp/README.md
+++ b/trqp/README.md
@@ -9,7 +9,7 @@ The Ayra TRQP Profile is a **profile** of TRQP v2.0. It:
 - **Requires** both `/authorization` and `/recognition` endpoints (TRQP v2.0 requires at least one). NOTE: either can return a 501 (NOT IMPLEMENTED), but both are required to conform with the Swagger/OAS specification.
 - **Constrains** identifiers to `did:webvh` (TRQP v2.0 allows any RFC 3986 URI).
 - **Adds** JWS response signing (not required by TRQP core).
-- **Adds** extension endpoints for metadata, entity lookup, assurance levels, authorizations, and DID methods.
+- **Adds** extension endpoints for metadata, entity lookup, assurance levels, authorizations, and DID methods. The Ayra metadata extension is intentionally profile-owned because TRQP v2.0 core does not prescribe a metadata endpoint.
 
 ## Schemas
 

--- a/trqp_ayra_profile_swagger.yaml
+++ b/trqp_ayra_profile_swagger.yaml
@@ -746,20 +746,23 @@ components:
 
     TrustRegistryMetadata:
       type: object
+      description: |
+        Ayra profile extension metadata returned by GET /metadata.
+        TRQP v2.0 core does not prescribe a metadata endpoint; this schema defines
+        the Ayra Trust Network profile contract.
       required:
         - ecosystem_did
         - description
       properties:
         ecosystem_did:
           type: string
-          description: Unique identifier of the Ecosystem that the Trust Registry is associated with. This is used in TRQP queries as the `ecosytem_id` value.
+          description: Unique identifier of the ecosystem that the Trust Registry is associated with. This is used in TRQP queries as the ecosystem identifier value.
         trustregistry_did:
           type: string
-          description: Unique identifier, as DID, of the Trust Registry. 
+          description: Unique identifier, as a DID, of the Trust Registry.
         egf_did:
           type: string
-          description: The Primary EGF, identified by DID, for the ecosystem.
-        
+          description: Primary Ecosystem Governance Framework (EGF), identified by DID, for the ecosystem.
         description:
           type: string
           maxLength: 4096
@@ -773,8 +776,7 @@ components:
           items:
             type: string
           minItems: 1
-        additionalProperties:
-            type: string
+      additionalProperties: false
 
     Authorization:
       type: object


### PR DESCRIPTION
## Summary
- Aligns schema/ayra_metadata.jsonschema with the OpenAPI TrustRegistryMetadata component.
- Fixes OpenAPI additionalProperties placement for the metadata schema.
- Adds a metadata schema drift check and wires it into CI.
- Updates docs to clarify /metadata as an Ayra extension outside TRQP v2.0 core.

## Verification
- python3 scripts/check_metadata_schema_drift.py
- python3 -m compileall -q scripts tests tools
- npx --yes @redocly/cli lint trqp_ayra_profile_swagger.yaml

Paperclip: AYR-247